### PR TITLE
chore: clean CODEOWNERS + add entry for .github/agents

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,11 @@
 # CODEOWNERS documentation : https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
+* @ContentSquare/tech-lead-qt
+
 # ==============
 # Platform stuff
 # ==============
 # !!! Always keep it on the last lines of the CODEOWNERS file !!!
-
-# Deployfile gives rights to modify productions resources
-/Deployfile @ContentSquare/Platform
-
-# Jenkinsfile has access to secrets and grants access to AWS resources
-/Jenkinsfile @ContentSquare/Platform
 
 # Makefile are called by Jenkinsfile and inherit their access
 Makefile* @ContentSquare/Platform
@@ -20,8 +16,8 @@ Dockerfile* @ContentSquare/Platform
 # .github controls CODEOWNERS and Github actions (not used at the moment)
 /.github/ @ContentSquare/Platform
 
-# .infra describes the production resources
-.infra/ @ContentSquare/Platform
+# Protect .github/agents folder for GitHub Copilot agents
+/.github/agents/ @ContentSquare/tech-lead-qt
 
 # ==============
 # Platform stuff


### PR DESCRIPTION
## Description
Add a CODEOWNERS entry to protect the `.github/agents/` folder

## Motivation and Context
Proactively protect the GitHub agents folder so that when GitHub Copilot agent configurations are added, they will require review from the repository owners.

## Breaking Changes
No

## How Has This Been Tested?
N/A - CODEOWNERS configuration change only